### PR TITLE
follow symlinks in conda parent dir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,10 +8,11 @@
     force={{ 'yes' if miniconda_installer_checksum == '' else 'no' }}
     mode=0755
 
-- name: directory {{ miniconda_prefix | dirname }} is exists
+- name: directory {{ miniconda_prefix | dirname }} exists
   file:
     path="{{ miniconda_prefix | dirname }}"
     state=directory
+    follow=yes
 
 - name: bzip2 is installed
   apt:


### PR DESCRIPTION
without this fix deployment of miniconda fails when the parent dir is a symlinked dir
