### PR TITLE
support to install/update modules in the default environment (named 'root')

### DIFF
--- a/tasks/environment.yml
+++ b/tasks/environment.yml
@@ -10,8 +10,8 @@
 
 - name: conda environment {{ miniconda_env.name }} is up-to-date
   command:
-    '"{{ miniconda_prefix }}/bin/conda" env update -n {{ miniconda_env.name }} -f "/tmp/{{ miniconda_env.name }}-environment.yml" -q QUIET'
+    '"{{ miniconda_prefix }}/bin/conda" env update -n "{{ miniconda_env.name }}" -f "/tmp/{{ miniconda_env.name }}-environment.yml" -q QUIET'
   register: miniconda_env_update
-  when: (miniconda_env_create !='') or ('"skipped" in miniconda_env_create.stdout')
+  when: (miniconda_env.name == 'root') or ('"skipped" in miniconda_env_create.stdout')
   changed_when: '"COMPLETE" in miniconda_env_update.stdout'
 

--- a/tasks/environment.yml
+++ b/tasks/environment.yml
@@ -6,12 +6,12 @@
   args:
     creates: '{{ miniconda_prefix }}/envs/{{ miniconda_env.name }}'
   register: miniconda_env_create
-  when: miniconda_env != ''
+  when: miniconda_env != '' and miniconda_env.name != 'root'
 
 - name: conda environment {{ miniconda_env.name }} is up-to-date
   command:
-    '"{{ miniconda_prefix }}/bin/conda" env update -f "/tmp/{{ miniconda_env.name }}-environment.yml" -q'
+    '"{{ miniconda_prefix }}/bin/conda" env update -n {{ miniconda_env.name }} -f "/tmp/{{ miniconda_env.name }}-environment.yml" -q QUIET'
   register: miniconda_env_update
-  when: '"skipped" in miniconda_env_create.stdout'
+  when: (miniconda_env_create !='') or ('"skipped" in miniconda_env_create.stdout')
   changed_when: '"COMPLETE" in miniconda_env_update.stdout'
 

--- a/tasks/environment.yml
+++ b/tasks/environment.yml
@@ -10,7 +10,7 @@
 
 - name: conda environment {{ miniconda_env.name }} is up-to-date
   command:
-    '"{{ miniconda_prefix }}/bin/conda" env update -n "{{ miniconda_env.name }}" -f "/tmp/{{ miniconda_env.name }}-environment.yml" -q QUIET'
+    '"{{ miniconda_prefix }}/bin/conda" env update -n "{{ miniconda_env.name }}" -f "/tmp/{{ miniconda_env.name }}-environment.yml"'
   register: miniconda_env_update
   when: (miniconda_env.name == 'root') or ('"skipped" in miniconda_env_create.stdout')
   changed_when: '"COMPLETE" in miniconda_env_update.stdout'


### PR DESCRIPTION
Just required small changes to the existing (well done and flexible) role, to allow the user to not just configure any custom environments, but also to deploy the defined environment/modules to the default/globally installed miniconda modules, simply by setting the miniconda_env.name=root.

Example config:
```
  miniconda_env:
    name: root
    dependencies:
     - python=2.7.12
     - pandas=0.18.1
...
     - pip:
       - slugify
```

Extra note:
- This PR also contains a small change in the 'conda env update' cmd, namely the '-q' parameter needs an argument to work ( `-q QUITE` ). Not sure if this is due to a recent conda change.
Anyway when checking other conda commands help (`-h `) they all still work with the simple `-q`. Very strange (and neither did I find any bug report in github/conda  about this inconsistency)
