### PR TITLE
Fix ansible lint rule ansible0013

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - ansible --version
   - printf '[defaults]\nroles_path=../\ncallback_whitelist=profile_tasks' > ansible.cfg
   - pip install ansible-lint
+  - ansible-lint --version
 
 script:
   - ansible-playbook -i localhost, --syntax-check tests/test.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,11 +20,10 @@
   when: ansible_os_family == "Debian"
 
 - name: miniconda is installed
-  shell:
-    '"/tmp/{{ miniconda_installer}}" -b -p "{{ miniconda_prefix }}"'
+  command:
+    '/bin/bash "/tmp/{{ miniconda_installer}}" -b -p "{{ miniconda_prefix }}"'
   args:
     creates: "{{ miniconda_prefix }}"
-    executable: /bin/bash
 
 - name: miniconda is up-to-date
   command: '"{{ miniconda_prefix }}/bin/conda" update conda -y -q'


### PR DESCRIPTION
Fix for ansible-lint rule `ANSIBLE0013` and show ansible-lint version for isolation.
related commit: c5c963da533dd