### PR TITLE
Add option to not install tar and bz2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ miniconda_installer_checksum: ""
 miniconda_prefix: "{{ ansible_env.HOME }}/miniconda{{ miniconda_python if miniconda_python == 3 else '' }}"
 miniconda_update_conda: False
 miniconda_env: ""
+miniconda_manage_dependencies: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,11 +18,13 @@
   package:
     name=tar
     state=present
+  when: miniconda_manage_dependencies
 
 - name: bzip2 is installed
   package:
     name=bzip2
     state=present
+  when: miniconda_manage_dependencies
 
 - name: miniconda is installed
   command:


### PR DESCRIPTION
This may be necessary when the conda environment should be owned by a
become user that has does not have the rights to use the package
manager.