### PR TITLE
move miniconda_installer to defaults (so it can be overriden in group_vars etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Available role variables are listed below, along with default values:
 ```yaml
 miniconda_python: 3
 miniconda_version: "3.16.0"
+miniconda_installer: Miniconda{{ "3" if miniconda_python == 3 or miniconda_version not in miniconda_oldversions else "" }}-{{ miniconda_version }}-{{ miniconda_systems[ansible_system] }}-{{ miniconda_architecture[ansible_architecture] }}.sh
 miniconda_installer_checksum: ""
 miniconda_prefix: "{{ ansible_env.HOME }}/miniconda{{ miniconda_python if miniconda_python == 3 else '' }}"
 miniconda_update_conda: False
@@ -25,6 +26,9 @@ default: `3`: install and use python3 based miniconda.
 
 `miniconda_version` is a variable to specify version of miniconda.
 default: `"3.16.0"`.
+
+`miniconda_installer` is a variable to specify the miniconda installer filename.
+default: defined by variables `miniconda_python`,`miniconda_version` and facts `ansible_system`,`ansible_architecture`
 
 `miniconda_installer_checksum:` is a variable to checksum for miniconda_installer.
 default: `""`, do not check the digest.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 miniconda_python: 3
 miniconda_version: "3.16.0"
+miniconda_installer: Miniconda{{ "3" if miniconda_python == 3 or miniconda_version not in miniconda_oldversions else "" }}-{{ miniconda_version }}-{{ miniconda_systems[ansible_system] }}-{{ miniconda_architecture[ansible_architecture] }}.sh
 miniconda_installer_checksum: ""
 miniconda_prefix: "{{ ansible_env.HOME }}/miniconda{{ miniconda_python if miniconda_python == 3 else '' }}"
 miniconda_update_conda: False

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,3 @@
-miniconda_installer: Miniconda{{ "3" if miniconda_python == 3 or miniconda_version not in miniconda_oldversions else "" }}-{{ miniconda_version }}-{{ miniconda_systems[ansible_system] }}-{{ miniconda_architecture[ansible_architecture] }}.sh
 miniconda_systems:
   Linux: Linux
   Darwin: MacOSX


### PR DESCRIPTION
a redo of https://github.com/uchida/ansible-miniconda-role/pull/4/files
with a small change that I added it into the defaults before the var `miniconda_installer_checksum`

Finally I've another reason (where I see no other solution), to overwrite that var:
* ensure that the a Miniconda2* installer is used when `miniconda_python: 2` is set, independent of some hard-to-understand depending variable `miniconda_oldversions` 

( ps: more PRs coming. I extra decided to make 1 per small feature, with the hope of getting stuff merged upstream 👍 )