### PR TITLE
new configurable vars allowing to pass custom options to the conda-env create/update cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ default: `True`, install `tar` and `bzip`.
 `miniconda_update_conda` is a variable to specify wheather to run `conda update conda` or not.
 default: `False`, do not update conda.
 
+`miniconda_env_create_opts` is a variable to specify extra options for the `conda env create` task
+default: `"-q"`, quiet mode (is recommended to ensure the create works)
+
+`miniconda_env_update_opts` is a variable to specify extra options for the `conda env update` task
+default: `""`, no additional opts
+useful to set '--prune' (remove installed packages not defined in environment)
+
 `miniconda_env` is a variable to specify conda environment to create.
 default: `""`, nothing will be created.
 its format is exactly same as conda env spec file, for example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ miniconda_prefix: "{{ ansible_env.HOME }}/miniconda{{ miniconda_python if minico
 miniconda_update_conda: False
 miniconda_env: ""
 miniconda_manage_dependencies: True
+miniconda_env_create_opts: '-q'
+miniconda_env_update_opts: ''

--- a/tasks/environment.yml
+++ b/tasks/environment.yml
@@ -2,7 +2,7 @@
 
 - name: conda environment {{ miniconda_env.name }} is created
   command:
-    '"{{ miniconda_prefix }}/bin/conda" env create -f "/tmp/{{ miniconda_env.name }}-environment.yml" -q'
+    '"{{ miniconda_prefix }}/bin/conda" env create -f "/tmp/{{ miniconda_env.name }}-environment.yml" {{ miniconda_env_create_opts }}'
   args:
     creates: '{{ miniconda_prefix }}/envs/{{ miniconda_env.name }}'
   register: miniconda_env_create
@@ -10,7 +10,7 @@
 
 - name: conda environment {{ miniconda_env.name }} is up-to-date
   command:
-    '"{{ miniconda_prefix }}/bin/conda" env update -n "{{ miniconda_env.name }}" -f "/tmp/{{ miniconda_env.name }}-environment.yml"'
+    '"{{ miniconda_prefix }}/bin/conda" env update -n "{{ miniconda_env.name }}" -f "/tmp/{{ miniconda_env.name }}-environment.yml" {{ miniconda_env_update_opts }}'
   register: miniconda_env_update
   when: (miniconda_env.name == 'root') or ('"skipped" in miniconda_env_create.stdout')
   changed_when: '"COMPLETE" in miniconda_env_update.stdout'


### PR DESCRIPTION
the updated README should be self-explaining for the 2 new options 👍 

Additonal info:
initially, while debugging issues where the `update` cmd took too long, like it was hanging
( which was finally due to known issue: https://github.com/conda/conda/issues/5219 )
I wanted to use the new opts also enable redirecting the live output of the running update cmd to a tmp out file, where I could see the progress (or if it hang again for minutes on the deps check), by adding following:
 ```
miniconda_env_update_opts:  "2>&1 | tee >/tmp/miniconda_deploy.out"
```
that unfort. is of course only working when using a `shell` (vs `command') task.
@uchida your opinion in using a 'shell' task for those cmds? ( I also agree that command would be the better default, just less flexible ).  I'ld also have to ensure that the task's stdout is still properly set (else the nice `changed_when` gets broken)